### PR TITLE
FAN-1385 Reenable DISPATCH_INTERNAL_CRASH for closed sockets

### DIFF
--- a/src/event/event_windows.c
+++ b/src/event/event_windows.c
@@ -219,11 +219,7 @@ _dispatch_muxnote_disarm_events(dispatch_muxnote_t dmn,
 			iResult = WSAEventSelect((SOCKET)dmn->dmn_ident, NULL, 0);
 		}
 		if (iResult != 0) {
-			// ignore error if socket was already closed
-			int err = WSAGetLastError();
-			if (err != WSAENOTSOCK) {
-				//DISPATCH_INTERNAL_CRASH(err, "WSAEventSelect");
-			}
+			DISPATCH_INTERNAL_CRASH(WSAGetLastError(), "WSAEventSelect");
 		}
 		dmn->dmn_network_events = lNetworkEvents;
 		if (!lNetworkEvents && dmn->dmn_threadpool_wait) {

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -240,7 +240,6 @@ extension DispatchQueue {
 	///
 	/// - parameter group: the dispatch group to associate with the submitted
 	/// work item. If this is `nil`, the work item is not associated with a group.
-	/// - parameter flags: flags that control the execution environment of the
 	/// - parameter qos: the QoS at which the work item should be executed.
 	///     Defaults to `DispatchQoS.unspecified`.
 	/// - parameter flags: flags that control the execution environment of the


### PR DESCRIPTION
This was a hatchet fix that we can (hopefully) finally back out